### PR TITLE
Add register and admin routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,13 @@ import {
 } from "react-router-dom";
 import Layout from "./components/Layout";
 import Login from "./pages/Login";
+import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import PatientForm from "./pages/PatientForm";
 import PatientDetail from "./pages/PatientDetail";
 import PrintPreview from "./pages/PrintPreview";
+import AdminPanel from "./pages/AdminPanel";
+import { getFirestore, getDoc, doc } from "firebase/firestore";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { useEffect, useState } from "react";
 
@@ -36,6 +39,37 @@ function RequireAuth() {
   return <Outlet />;
 }
 
+function RequireAdmin() {
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const auth = getAuth();
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (firebaseUser) {
+        const db = getFirestore();
+        const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
+        const data = userDoc.data();
+        setIsAdmin(data?.role === "admin");
+      } else {
+        setIsAdmin(false);
+      }
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  if (loading) {
+    return <div>Carregando...</div>;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}
+
 function App() {
   return (
     <Router>
@@ -47,10 +81,14 @@ function App() {
             <Route path="patient-form" element={<PatientForm />} />
             <Route path="patient-detail/:id" element={<PatientDetail />} />
             <Route path="print-preview" element={<PrintPreview />} />
+            <Route element={<RequireAdmin />}>
+              <Route path="admin" element={<AdminPanel />} />
+            </Route>
           </Route>
         </Route>
         {/* Rotas públicas */}
         <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
       </Routes>
     </Router>
   );


### PR DESCRIPTION
## Summary
- import AdminPanel and Register pages in `App.tsx`
- implement `RequireAdmin` gate to guard admin-only pages
- expose `/register` and `/admin` routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876ebc448a4833194677b9f0841b90a