### PR TITLE
Add Firestore write on register

### DIFF
--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -10,6 +10,7 @@ import {
   createTheme,
 } from "@mui/material";
 import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+import { getFirestore, setDoc, doc } from "firebase/firestore";
 
 const theme = createTheme({
   palette: {
@@ -39,8 +40,19 @@ function Register() {
     }
     const auth = getAuth();
     try {
-      await createUserWithEmailAndPassword(auth, email, password);
-      setSuccess("Usuário criado com sucesso! Redirecionando para login...");
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password,
+      );
+      const db = getFirestore();
+      await setDoc(doc(db, "users", userCredential.user.uid), {
+        email,
+        role: "user",
+      });
+      setSuccess(
+        "Usuário criado com sucesso! Redirecionando para login...",
+      );
       setTimeout(() => navigate("/login"), 2000);
     } catch (err: unknown) {
       if (err instanceof Error) {


### PR DESCRIPTION
## Summary
- save new user's email and default role in Firestore after registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876eccb5cd083318e9b70ef20bcb633