### PR TITLE
Implement RequireAdmin and store roles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Outlet,
 } from "react-router-dom";
 import Layout from "./components/Layout";
+import RequireAdmin from "./components/RequireAdmin";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
@@ -13,7 +14,6 @@ import PatientForm from "./pages/PatientForm";
 import PatientDetail from "./pages/PatientDetail";
 import PrintPreview from "./pages/PrintPreview";
 import AdminPanel from "./pages/AdminPanel";
-import { getFirestore, getDoc, doc } from "firebase/firestore";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { useEffect, useState } from "react";
 
@@ -39,36 +39,6 @@ function RequireAuth() {
   return <Outlet />;
 }
 
-function RequireAdmin() {
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-      if (firebaseUser) {
-        const db = getFirestore();
-        const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
-        const data = userDoc.data();
-        setIsAdmin(data?.role === "admin");
-      } else {
-        setIsAdmin(false);
-      }
-      setLoading(false);
-    });
-    return () => unsubscribe();
-  }, []);
-
-  if (loading) {
-    return <div>Carregando...</div>;
-  }
-
-  if (!isAdmin) {
-    return <Navigate to="/" replace />;
-  }
-
-  return <Outlet />;
-}
 
 function App() {
   return (

--- a/src/components/RequireAdmin.tsx
+++ b/src/components/RequireAdmin.tsx
@@ -1,0 +1,37 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { getFirestore, doc, getDoc } from "firebase/firestore";
+import { useEffect, useState } from "react";
+
+function RequireAdmin() {
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const auth = getAuth();
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (firebaseUser) {
+        const db = getFirestore();
+        const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
+        const data = userDoc.data();
+        setIsAdmin(data?.role === "admin");
+      } else {
+        setIsAdmin(false);
+      }
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  if (loading) {
+    return <div>Carregando...</div>;
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}
+
+export default RequireAdmin;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -10,6 +10,7 @@ import {
   createTheme,
 } from "@mui/material";
 import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+import { getFirestore, setDoc, doc } from "firebase/firestore";
 
 const theme = createTheme({
   palette: {
@@ -39,7 +40,16 @@ function Register() {
     }
     const auth = getAuth();
     try {
-      await createUserWithEmailAndPassword(auth, email, password);
+      const userCredential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      const db = getFirestore();
+      await setDoc(doc(db, "users", userCredential.user.uid), {
+        email,
+        role: "user",
+      });
       setSuccess("Usuário criado com sucesso! Redirecionando para login...");
       setTimeout(() => navigate("/login"), 2000);
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- guard admin routes with `RequireAdmin` component
- save user role in Firestore when registering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876ecc8d2a48331bf9146dd4e71b90f